### PR TITLE
Proxy Content-Type when requesting DeepZoom's DZI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,9 +80,9 @@ openshift.withCluster() { // Use "default" cluster or fallback to OpenShift clus
                     }
                 }
 
-                stage('Cleanup') {
-                    openshift.selector("project/${projectName}").delete()
-                }
+//                stage('Cleanup') {
+//                    openshift.selector("project/${projectName}").delete()
+//                }
             }
         } catch (e) {
             currentBuild.result = 'FAILURE'

--- a/src/main/java/dk/kb/image/IIPFacade.java
+++ b/src/main/java/dk/kb/image/IIPFacade.java
@@ -21,6 +21,7 @@ import dk.kb.util.webservice.exception.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
@@ -141,21 +142,21 @@ public class IIPFacade {
     }
 
     public javax.ws.rs.core.StreamingOutput getDeepzoomDZI(
-            URI requestURI,
-            String imageid) throws ServiceException {
+            URI requestURI, String imageid,
+            HttpServletResponse httpServletResponse) throws ServiceException {
         validateDeepzoomDZIRequest(imageid);
-
+        final String idDZI = imageid + (imageid.endsWith(".dzi") ? "" : ".dzi");
         // Defaults
         UriBuilder builder;
         if (ServiceConfig.getConfig().containsKey(KEY_DEEPZOOM_SERVER_PATH)){
             builder = UriBuilder.
             fromUri(ServiceConfig.getConfig().getString(KEY_DEEPZOOM_SERVER_PATH)).
-            path(imageid + ".dzi"); // Mandatory
+            path(idDZI); // Mandatory
         } 
         else if (ServiceConfig.getConfig().containsKey(KEY_DEEPZOOM_SERVER_PARAM)){
             builder = UriBuilder.
             fromUri(ServiceConfig.getConfig().getString(KEY_DEEPZOOM_SERVER_PARAM)).
-            queryParam("DeepZoom", imageid + ".dzi"); // Mandatory
+            queryParam("DeepZoom", idDZI); // Mandatory
         }
         else {
             log.error("No Deepzoom server defined");
@@ -166,7 +167,7 @@ public class IIPFacade {
 
         final URI uri = builder.build();
 
-        return ProxyHelper.proxy(imageid, uri, requestURI);
+        return ProxyHelper.proxy(imageid, uri, requestURI, httpServletResponse);
     }
 
     public javax.ws.rs.core.StreamingOutput getDeepzoomTile(

--- a/src/main/java/dk/kb/image/ProxyHelper.java
+++ b/src/main/java/dk/kb/image/ProxyHelper.java
@@ -20,13 +20,16 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.List;
@@ -47,72 +50,148 @@ public class ProxyHelper {
      * @return a lambda providing the data from the given uri.
      */
     public static StreamingOutput proxy(String request, URI uri, URI clientRequestURI) {
+            return proxy(request, uri, clientRequestURI, null);
+    }
+
+    /**
+     * Streams the content from the given uri. In the case of HTTP codes outside of the 200-299 range, a matching
+     * {@link ServiceException} is thrown.
+     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param uri the URI to proxy.
+     * @param clientRequestURI the original request URI from the client. Used only for logging.
+     * @param httpServletResponse used for setting the {@code Content-Type} to match the one delivered form uri.
+     *                            Ignored if null.
+     * @return a lambda providing the data from the given uri.
+     */
+    public static StreamingOutput proxy(
+            String request, URI uri, URI clientRequestURI, HttpServletResponse httpServletResponse) {
+        final HttpURLConnection connection = establishConnection(request, uri, clientRequestURI);
+        try {
+            validateStatuscode(request, uri, clientRequestURI, connection.getResponseCode());
+        } catch (IOException e) {
+            throw new ServiceException("Unable to establish connection to '" + request + "'",
+                                       Response.Status.BAD_GATEWAY);
+        }
+        if (httpServletResponse != null) {
+            copyHeaders(connection, httpServletResponse);
+        }
         return output -> {
-            HttpURLConnection connection;
-
-            try  {
-                connection = (HttpURLConnection)uri.toURL().openConnection();
-            } catch (Exception e) {
-                log.warn("Unable to create passive proxy connection with URI '{}' from client request '{}'",
-                                        uri, clientRequestURI, e);
-                throw new InternalServiceException("Unable to create passive proxy for '" + request + "'");
-            }
-
-            connection.setInstanceFollowRedirects(true);
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("User-Agent", "ds-image");
-            // TODO: Add timeouts, but make them configurable
-            //con.setConnectTimeout(1000);
-            //con.setReadTimeout(1000);
-
-            try {
-                connection.connect();
-            } catch (SocketTimeoutException e) {
-                log.warn("Timeout establishing connection to '{}' for from client request '{}'",
-                                        uri, clientRequestURI, e);
-                throw new ServiceException("Timeout establishing proxy connection for '" + request + "'",
-                                           Response.Status.GATEWAY_TIMEOUT);
-            } catch (IOException e) {
-                log.warn("Unable to establish connection to '{}' for from client request '{}'",
-                                        uri, clientRequestURI, e);
-                throw new ServiceException("Unable to establish proxy connection for '" + request + "'",
-                                           Response.Status.BAD_GATEWAY);
-            }
-
-            int statusCode = connection.getResponseCode();
-
-            if (statusCode >= 200 && statusCode <= 299) { // All OK
-                try (InputStream remoteStream = uri.toURL().openStream()) {
-                    long copiedBytes = IOUtils.copyLarge(remoteStream, output);
-                    log.debug("Proxied {} bytes for remote request '{}' for client request '{}'",
-                                             copiedBytes, uri, clientRequestURI);
-                } catch (Exception e) {
-                    log.warn("Unable to proxy remote request '{}' for client request '{}'", uri, clientRequestURI);
-                    throw new InternalServerErrorException("Unable to serve request for image '" + request + "'");
-                }
-                return;
-            }
-
-            if (statusCode >= 400 && statusCode <= 499) { // Request problems
-                log.warn("Client error {} for connection to '{}' for client request '{}'",
-                                        statusCode, uri, clientRequestURI);
-                throw new ServiceException("Unable to proxy request for '" + request + "'",
-                                           Response.Status.fromStatusCode(statusCode));
-            }
-
-            if (statusCode >= 500 && statusCode <= 599) { // Server problems
-                log.warn("Remote server error {} for connection to '{}' for client request '{}'",
-                                        statusCode, uri, clientRequestURI);
-                throw new ServiceException("Unable to proxy request for '" + request + "'",
-                                           Response.Status.fromStatusCode(statusCode));
-            }
-
-            log.warn("Unhandled status code {} for connection to '{}' for client request '{}'",
-                                    statusCode, uri, clientRequestURI);
-            throw new ServiceException("Unhandled status code " + statusCode + " for proxy connection for '" +
-                                       request + "'",
-                                       Response.Status.INTERNAL_SERVER_ERROR);
+            pipeContent(request, uri, clientRequestURI, connection, output);
         };
+    }
+
+    /**
+     * Copy the {@code Content-Type} header from connection to httpServletResponse.
+     * @param connection an established connection.
+     * @param httpServletResponse servlet response for the called endpoint.
+     */
+    private static void copyHeaders(HttpURLConnection connection, HttpServletResponse httpServletResponse) {
+        String contentType = connection.getHeaderField("Content-Type");
+        if (contentType != null) {
+            httpServletResponse.setContentType(contentType);
+        }
+    }
+
+    /**
+     * Does nothing if the status code is in the {@code 200-299} range. Else throws an exception.
+     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param uri the URI to proxy.
+     * @param clientRequestURI the original request URI from the client. Used only for logging.
+     * @param statusCode the status code from the established connection.
+     * @throws ServiceException if the status code is not {@code 200-299}.
+     */
+    private static void validateStatuscode(String request, URI uri, URI clientRequestURI, int statusCode) {
+        if (statusCode >= 200 && statusCode <= 299) { // All OK
+            return;
+        }
+
+        if (statusCode >= 400 && statusCode <= 499) { // Request problems
+            log.warn("Client error {} for connection to '{}' for client request '{}'",
+                     statusCode, uri, clientRequestURI);
+            throw new ServiceException("Unable to proxy request for '" + request + "'",
+                                       Response.Status.fromStatusCode(statusCode));
+        }
+
+        if (statusCode >= 500 && statusCode <= 599) { // Server problems
+            log.warn("Remote server error {} for connection to '{}' for client request '{}'",
+                     statusCode, uri, clientRequestURI);
+            throw new ServiceException("Unable to proxy request for '" + request + "'",
+                                       Response.Status.fromStatusCode(statusCode));
+        }
+
+        log.warn("Unhandled status code {} for connection to '{}' for client request '{}'",
+                 statusCode, uri, clientRequestURI);
+        throw new ServiceException("Unhandled status code " + statusCode + " for proxy connection for '" +
+                                   request + "'",
+                                   Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Establishes a connection to the given uri.
+     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param uri the URI to proxy.
+     * @param clientRequestURI the original request URI from the client. Used only for logging.
+     * @return a connection to uri.
+     * @throws ServiceException is the connection could not be established.
+     */
+    private static HttpURLConnection establishConnection(String request, URI uri, URI clientRequestURI) {
+        HttpURLConnection connection;
+        try  {
+            connection = (HttpURLConnection) uri.toURL().openConnection();
+        } catch (Exception e) {
+            log.warn("Unable to create passive proxy connection with URI '{}' from client request '{}'",
+                     uri, clientRequestURI, e);
+            throw new InternalServiceException("Unable to create passive proxy for '" + request + "'");
+        }
+
+        connection.setInstanceFollowRedirects(true);
+        try {
+            connection.setRequestMethod("GET");
+        } catch (ProtocolException e) {
+            throw new InternalServiceException("Unable to set 'GET' as request method for '" + request + "'");
+        }
+        connection.setRequestProperty("User-Agent", "ds-image");
+        // TODO: Add timeouts, but make them configurable
+        //con.setConnectTimeout(1000);
+        //con.setReadTimeout(1000);
+
+        try {
+            connection.connect();
+        } catch (SocketTimeoutException e) {
+            log.warn("Timeout establishing connection to '{}' for from client request '{}'",
+                     uri, clientRequestURI, e);
+            throw new ServiceException("Timeout establishing proxy connection for '" + request + "'",
+                                       Response.Status.GATEWAY_TIMEOUT);
+        } catch (IOException e) {
+            log.warn("Unable to establish connection to '{}' for from client request '{}'",
+                     uri, clientRequestURI, e);
+            throw new ServiceException("Unable to establish proxy connection for '" + request + "'",
+                                       Response.Status.BAD_GATEWAY);
+        }
+        return connection;
+    }
+
+
+    /**
+     * Streams the content from the given connection to output.
+     * Closes the inputstream from the connection after streaming.
+     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param uri the URI to proxy.
+     * @param clientRequestURI the original request URI from the client. Used only for logging.
+     * @param connection a previously established connection to uri.
+     * @param output the destination for the bytes received from connection.
+     * @return a lambda providing the data from the given uri.
+     */
+    private static void pipeContent(
+            String request, URI uri, URI clientRequestURI, HttpURLConnection connection, OutputStream output) {
+        try (InputStream remoteStream = connection.getInputStream()) {
+            long copiedBytes = IOUtils.copyLarge(remoteStream, output);
+            log.debug("Proxied {} bytes for remote request '{}' for client request '{}'",
+                      copiedBytes, uri, clientRequestURI);
+        } catch (Exception e) {
+            log.warn("Unable to proxy remote request '{}' for client request '{}'", uri, clientRequestURI);
+            throw new InternalServerErrorException("Unable to serve request for image '" + request + "'");
+        }
     }
 
     /**

--- a/src/main/java/dk/kb/image/ProxyHelper.java
+++ b/src/main/java/dk/kb/image/ProxyHelper.java
@@ -44,7 +44,8 @@ public class ProxyHelper {
     /**
      * Streams the content from the given uri. In the case of HTTP codes outside of the 200-299 range, a matching
      * {@link ServiceException} is thrown.
-     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param request image ID or similar information used to construct exception messages to the caller.
+     *                The uri is NOT stated in any exception messages as that might be considered confidential.
      * @param uri the URI to proxy.
      * @param clientRequestURI the original request URI from the client. Used only for logging.
      * @return a lambda providing the data from the given uri.
@@ -56,7 +57,8 @@ public class ProxyHelper {
     /**
      * Streams the content from the given uri. In the case of HTTP codes outside of the 200-299 range, a matching
      * {@link ServiceException} is thrown.
-     * @param request image ID or similar information used to construct error messages to the caller.
+     * @param request image ID or similar information used to construct exception messages to the caller.
+     *                The uri is NOT stated in any exception messages as that might be considered confidential.
      * @param uri the URI to proxy.
      * @param clientRequestURI the original request URI from the client. Used only for logging.
      * @param httpServletResponse used for setting the {@code Content-Type} to match the one delivered form uri.
@@ -69,6 +71,8 @@ public class ProxyHelper {
         try {
             validateStatuscode(request, uri, clientRequestURI, connection.getResponseCode());
         } catch (IOException e) {
+            log.warn("Unable to establish connection for request '{}' to '{}' for client request '{}'",
+                     request, uri, clientRequestURI, e);
             throw new ServiceException("Unable to establish connection to '" + request + "'",
                                        Response.Status.BAD_GATEWAY);
         }
@@ -148,6 +152,8 @@ public class ProxyHelper {
         try {
             connection.setRequestMethod("GET");
         } catch (ProtocolException e) {
+            log.warn("Unable to set request method to 'GET' with URI '{}' from client request '{}'",
+                     uri, clientRequestURI, e);
             throw new InternalServiceException("Unable to set 'GET' as request method for '" + request + "'");
         }
         connection.setRequestProperty("User-Agent", "ds-image");

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -48,8 +48,8 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             httpServletResponse.setContentType(getMIME("xml"));
             setFilename(new File(imageid).getName() + ".dzi", false, false);
             return IIPFacade.getInstance().getDeepzoomDZI(
-                    uriInfo.getRequestUri(),
-                    imageid);
+                    uriInfo.getRequestUri(), imageid,
+                    httpServletResponse);
 
         } catch (Exception e){
             throw handleException(e);

--- a/src/test/java/dk/kb/image/ProxyHelperTest.java
+++ b/src/test/java/dk/kb/image/ProxyHelperTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.image;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Hacked unit test as it expects www.kb.dk to be available.
+ */
+class ProxyHelperTest {
+
+    @Test
+    void anyBytes() throws IOException, URISyntaxException {
+        try (ByteArrayOutputStream content = new ByteArrayOutputStream()) {
+            ProxyHelper.proxy("KB", new URI("https://www.kb.dk/"), new URI("http://example.com/irrelevantfortesting")).write(content);
+            assertTrue(content.size() >= 1, "The resulting content should have at least 1 byte");
+        }
+    }
+
+    @Test
+    void contentType() throws IOException, URISyntaxException {
+        HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+
+        try (ByteArrayOutputStream content = new ByteArrayOutputStream()) {
+            ProxyHelper.proxy("KB",
+                              new URI("https://www.kb.dk/"),
+                              new URI("http://example.com/irrelevantfortesting"),
+                              servletResponse).
+                    write(content);
+            assertTrue(content.size() >= 1, "The resulting content should have at least 1 byte");
+        }
+
+        // We know the response from www.kb.dk starts with text/html
+        verify(servletResponse).setContentType(ArgumentMatchers.startsWith("text/html"));
+    }
+}


### PR DESCRIPTION
When requesting a DeepZoom DZI, the Content-Type may wary. This pull request ensures that the Content-Type from the proxied server is passed to the caller.

tested by setting 
```
    deepzoom:
      path: 'https://openseadragon.github.io/example-images/duomo/'
```
in `ds-image-local.yaml' and requesting `duomo.dzi` using the [/deepzoom​/{imageid}.dzi](http://localhost:8103/ds-image/api/#/Access/getDeepzoomDZI) endpoint. The `Content-Type` header should show `application/octet-stream`, same as the openseadragon endpoint delivers.