### PR TITLE
Make IIIF and Deepzoom endpoint handle IDs with slash

### DIFF
--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -3,6 +3,7 @@ package dk.kb.image.api.v1.impl;
 import dk.kb.image.IIIFFacade;
 import dk.kb.image.IIPFacade;
 import dk.kb.image.api.v1.AccessApi;
+import dk.kb.image.model.v1.IIIFInfoDto;
 import dk.kb.util.webservice.ImplBase;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.ServiceException;
@@ -142,8 +143,30 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
      */
     @Override
     public javax.ws.rs.core.StreamingOutput getImageInformation(String identifier, String format) throws ServiceException {
+        return rawGetImageInformation(identifier, format);
+    }
+
+    /*
+     * Manually specified handler for IIIF IDs containing non-escaped slashes.
+     * This will always preceed the OpenAPI-generated handler, but that should not be a problem.
+     */
+    @GET
+    @Path("/IIIF/{identifier:.*}/info.{format}")
+    @Produces({ "application/ld+json", "application/xml" })
+    @ApiOperation(value = "IIIF Image Information Nonescaped", tags={ "Access",  })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Succes!", response = IIIFInfoDto.class) })
+    public javax.ws.rs.core.StreamingOutput getImageInformationNonescaped(@PathParam("identifier") String identifier, @PathParam("format") String format) throws ServiceException {
+        return rawGetImageInformation(identifier, format);
+    }
+
+    /**
+     * The implementation of {@link #getImageInformation(String, String)}.
+     * They need to be two different methods as {@link #getImageInformationNonescaped(String, String)}
+     * is Apache CXF annotated and cannot be called directly from {@link #getImageInformationNonescaped(String, String)}
+     */
+    private javax.ws.rs.core.StreamingOutput rawGetImageInformation(String identifier, String format) throws ServiceException {
         try {
-            log.debug("getImageInformation(identifier='{}'m format='{}') called with call details: {}",
+            log.debug("getImageInformation(identifier='{}' format='{}') called with call details: {}",
                       identifier, format, getCallDetails());
             String[] elements = identifier.split("[/\\\\]");
             String filename = "info_" + elements[elements.length - 1] + "." + format;

--- a/src/main/openapi/ds-image-openapi_v1.yaml
+++ b/src/main/openapi/ds-image-openapi_v1.yaml
@@ -25,7 +25,9 @@ servers:
     description: 'Version 1'
 
 paths:
-# IIIF Image request
+  # IIIF Image request
+  # Note: If the signature of this endpoint is changed, AccessApiServiceImpl.iIIFRequestNonescaped must
+  #       be manually adjusted to match the new AccessApiServiceImpl.iIIFRequest annotations
   /IIIF/{identifier}/{region}/{size}/{rotation}/{quality}.{format}:
     get:
       tags:
@@ -180,7 +182,9 @@ paths:
             
             A rotation value that is out of range or unsupported should result in a 400 (Bad Request) status code.
             
-  # IIIF Image Information          
+  # IIIF Image Information
+  # Note: If the signature of this endpoint is changed, AccessApiServiceImpl.getImageInformationNonescaped must
+  #       be manually adjusted to match the new AccessApiServiceImpl.getImageInformation annotations
   /IIIF/{identifier}/info.{format}:
     get:
       tags:

--- a/src/main/openapi/ds-image-openapi_v1.yaml
+++ b/src/main/openapi/ds-image-openapi_v1.yaml
@@ -406,6 +406,8 @@ paths:
           description: An image with the provided FIF was not found.
   
   # DeepZoom
+  # Note: If the signature of this endpoint is changed, AccessApiServiceImpl.getDeepzoomDZINonescaped must
+  #       be manually adjusted to match the new AccessApiServiceImpl.getDeepzoomDZI annotations
   /deepzoom/{imageid}.dzi:
     get:
       tags:
@@ -441,6 +443,8 @@ paths:
                 schema:
                   $ref: '#/components/schemas/DeepzoomDZI'
                   
+  # Note: If the signature of this endpoint is changed, AccessApiServiceImpl.getDeepzoomTileNonescaped must
+  #       be manually adjusted to match the new AccessApiServiceImpl.getDeepzoomTile annotations
   /deepzoom/{imageid}_files/{layer}/{tiles}.{format}:
     get:
       tags:


### PR DESCRIPTION
This is practically the same changes as for https://github.com/kb-dk/ds-present/pull/42

OpenAPI does not handle nonescaped slashed inside of paths (and rightly so as it is against the standard) and the IIIF standard [requires encoding](https://iiif.io/api/image/3.0/#3-identifier). Nevertheless it is accepted practice in the wild to not escape such IDs.

The OpenAPI 3 generator produces methods with this type of annotation:
```
    @Path("/IIIF/{identifier}/manifest")
```
and thus requires `identifier` to be escaped.

This pull request works around this by creating a parallel endpoint with manual generated Apache CXF annotation instead of the OpenAPI generated one. CXF has no problem with wildcards in the `Path`, so by annotating a new endpoint with
```
    @Path("/IIIF/{nonescaped:.*}/manifest")
```
the `nonescaped` parameter can contain both escaped and nonescaped slashes.

This pull request applies the hack to both IIIF- and Deepzoom-endpoints. It is not currently deployed to the devel server, but this should be trivial with aegis.


### Two things that does not work

1. jetty does not like _leading_ slashes in the IDs. Or rather, it does not like consecutive slashes `http://example.com/foo//bar`. It is possible to make jetty accept it (See `AMBIGUOUS_EMPTY_SEGMENT` on https://stackoverflow.com/questions/74395500/jetty-returns-400-when-uri-has-2-slashes-in-a-row-while-tomcat-doesnt-care) but I have not discovered how to do so with the Maven Jatty Plugin.
2. Single-escaping `foo%2Fbar` still does not work and produces `Invalid URI: noSlash` in Tomcat (works fine with Jetty). We might be able to to convince our devel-Tomcat to accept it, but I have not explored that.
