### PR TITLE
Add access control to DeepZoom tiles

### DIFF
--- a/src/main/java/dk/kb/image/ProxyHelper.java
+++ b/src/main/java/dk/kb/image/ProxyHelper.java
@@ -125,6 +125,13 @@ public class ProxyHelper {
                                        Response.Status.fromStatusCode(statusCode));
         }
 
+        if (statusCode == -1) {
+            log.warn("Remote response not valid HTTP (-1) for connection to '{}' for client request '{}'",
+                    uri, clientRequestURI);
+            throw new ServiceException("Unable to proxy request for '" + request + "' due to proxied server error -1",
+                    Response.Status.fromStatusCode(500));
+        }
+
         log.warn("Unhandled status code {} for connection to '{}' for client request '{}'",
                  statusCode, uri, clientRequestURI);
         throw new ServiceException("Unhandled status code " + statusCode + " for proxy connection for '" +

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -156,6 +156,11 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
                       imageid, layer, tiles, format,
                       CNT, GAM, CMP, CTW, INV, COL,
                       getCallDetails());
+            StreamingOutput handleNoAccessOrNoImage = ImageAccessValidation.handleNoAccessOrNoImage(imageid, httpServletResponse);
+            if (handleNoAccessOrNoImage != null) {
+                return handleNoAccessOrNoImage;
+            }
+
             httpServletResponse.setContentType(getMIME(format));
             httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             return IIPFacade.getInstance().getDeepzoomTile(
@@ -292,15 +297,16 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             String filename = elements[elements.length - 1] + "." + format;
             // Show download link in Swagger UI, inline when opened directly in browser
             
-            //Will return null if there is access to the image.
-            StreamingOutput handleNoAccessOrNoImage = ImageAccessValidation.handleNoAccessOrNoImage(identifier, httpServletResponse);
-            if (handleNoAccessOrNoImage != null) {                
-                return handleNoAccessOrNoImage;
-            }
-                        
+
             setFilename(filename, false, false);
             httpServletResponse.setContentType(getMIME(format));
             httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
+
+            //Will return null if there is access to the image.
+            StreamingOutput handleNoAccessOrNoImage = ImageAccessValidation.handleNoAccessOrNoImage(identifier, httpServletResponse);
+            if (handleNoAccessOrNoImage != null) {
+                return handleNoAccessOrNoImage;
+            }
 
             return IIIFFacade.getInstance().getIIIFImage(
                     uriInfo.getRequestUri(),

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -16,20 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.DecimalMin;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.StreamingOutput;
-
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * ds-image
@@ -86,6 +76,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             log.debug("getDeepzoomDZI(imageid='{}') called with call details: {}", imageid, getCallDetails());
             // MIME-TYPE has to be set in proxy helper
             httpServletResponse.setContentType(getMIME("xml"));
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             setFilename(new File(imageid).getName() + ".dzi", false, false);
             return IIPFacade.getInstance().getDeepzoomDZI(
                     uriInfo.getRequestUri(), imageid,
@@ -166,6 +157,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
                       CNT, GAM, CMP, CTW, INV, COL,
                       getCallDetails());
             httpServletResponse.setContentType(getMIME(format));
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             return IIPFacade.getInstance().getDeepzoomTile(
                     uriInfo.getRequestUri(),
                     imageid, layer, tiles, format, CNT, GAM, CMP, CTW, INV, COL);
@@ -223,6 +215,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             // Show download link in Swagger UI, inline when opened directly in browser
             setFilename(filename, false, false);
             httpServletResponse.setContentType(getMIME(format));
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
 
             // TODO: Add support for XML when the OpenAPI specification has been corrected
             return IIIFFacade.getInstance().getIIIFInfo(uriInfo.getRequestUri(), identifier, "json");
@@ -307,6 +300,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
                         
             setFilename(filename, false, false);
             httpServletResponse.setContentType(getMIME(format));
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
 
             return IIIFFacade.getInstance().getIIIFImage(
                     uriInfo.getRequestUri(),
@@ -385,6 +379,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             // Show download link in Swagger UI, inline when opened directly in browser
             setFilename(filename, false, false);
             httpServletResponse.setContentType(getMIME(CVT));
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
 
             return IIPFacade.getInstance().getIIPImage(
                     uriInfo.getRequestUri(),

--- a/src/main/java/dk/kb/image/api/v1/impl/ServiceApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/ServiceApiServiceImpl.java
@@ -25,6 +25,7 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
     public String ping() throws ServiceException {
         try{
             log.debug("ping() called with call details: {}", getCallDetails());
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             return "Pong";
         } catch (Exception e){
             throw handleException(e);
@@ -48,6 +49,7 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
             } catch (UnknownHostException e) {
                 log.warn("Exception resolving hostname", e);
             }
+            httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             return new StatusDto()
                     .application(BuildInfoManager.getName())
                     .version(BuildInfoManager.getVersion())


### PR DESCRIPTION
This pull request adds very inefficient access checking to DeepZoom tiles.

The inefficiency is expected to be handled by a later update to the `ds-license` client in the form of caching.