### PR TITLE
Bugfix: logback config resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bugfix: Bumped slf4j and logback-classic to latest versions to re-enable logging
 
 
 ## [1.1.0](https://github.com/kb-dk/ds-image/releases/tag/v1.1.0) - 2023-12-05

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>ds-image</name> <!-- Human readable name, uppercase and spaces welcome -->
     <groupId>dk.kb.image</groupId>
     <artifactId>ds-image</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     
     <packaging>war</packaging>
     <description>ds-image by the Royal Danish Library</description>
@@ -192,6 +192,13 @@
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
             <version>7.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- The slf4j-simple logs to stderr and stdout, ignoring logback.xml -->
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <!-- URI templating by RFC6570 -->
@@ -205,7 +212,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -225,7 +232,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.11</version>
+            <version>1.4.14</version>
         </dependency>
 
         <!-- Unit test -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>dk.kb.license</groupId>
         <artifactId>ds-license</artifactId>
-          <version>1.1</version>
+          <version>1.3.8</version>
           <type>jar</type>
           <classifier>classes</classifier>
           <exclusions>

--- a/src/main/java/dk/kb/image/IIIFFacade.java
+++ b/src/main/java/dk/kb/image/IIIFFacade.java
@@ -35,7 +35,7 @@ public class IIIFFacade {
 
     private static IIIFFacade instance;
 
-    public static final String KEY_IIIF_SERVER = "mageservers.iiif.server";
+    public static final String KEY_IIIF_SERVER = "imageservers.iiif.server";
 
     // https://iiif.io/api/image/3.0/
     public static final String IIIF_IMAGE3_TEMPLATE = "/{identifier}/{region}/{size}/{rotation}/{quality}.{format}";

--- a/src/main/java/dk/kb/image/webservice/ContextListener.java
+++ b/src/main/java/dk/kb/image/webservice/ContextListener.java
@@ -1,17 +1,26 @@
 package dk.kb.image.webservice;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.util.StatusPrinter;
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.util.BuildInfoManager;
+import dk.kb.util.Files;
+import dk.kb.util.Resolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +32,8 @@ import org.slf4j.LoggerFactory;
 public class ContextListener implements ServletContextListener {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    public static final String LOGBACK_ENV = "java:/comp/env/ds-image-logback-config";
+    public static final String CONFIG_ENV = "java:/comp/env/application-config";
 
     /**
      * On context initialisation this
@@ -33,6 +44,9 @@ public class ContextListener implements ServletContextListener {
      */
     @Override
     public void contextInitialized(ServletContextEvent sce) {
+        // Workaround for logback problem. This should be called before any logging takes place
+        initLogging();
+
         try {
             RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
             if (mxBean.getInputArguments().stream().noneMatch(arg -> arg.startsWith("-Xmx"))) {
@@ -44,14 +58,107 @@ public class ContextListener implements ServletContextListener {
                      System.getProperty("java.version"), Runtime.getRuntime().maxMemory()/1048576,
                      InetAddress.getLocalHost().getHostName());
             InitialContext ctx = new InitialContext();
-            String configFile = (String) ctx.lookup("java:/comp/env/application-config");
+            String configFile = (String) ctx.lookup(CONFIG_ENV);
             //TODO this should not refer to something in template. Should we perhaps use reflection here?
             ServiceConfig.getInstance().initialize(configFile);
         } catch (NamingException e) {
             throw new RuntimeException("Failed to lookup settings", e);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load settings", e);        } 
+            throw new RuntimeException("Failed to load settings", e);
+        }
+
         log.info("Service initialized.");
+    }
+
+    /**
+     * For unfathomable reasons, logback 1.4.11 does not support the construction
+     * <pre>
+     * &lt;configuration scan="true" scanPeriod="5 minutes"&gt;
+     *     &lt;insertFromJNDI env-entry-name="java:comp/env/ds-image-logback-config" as="logbackConfiguration"/&gt;
+     *     &lt;include file="${logbackConfiguration}"/&gt;
+     * &lt;/configuration&gt;    
+     * </pre>
+     * as the JNDI injection is performed <strong>after</strong> the {@code include}.
+     * <p>
+     * The workaround is to programatically perform the same environment lookup and reconfigure logback to use
+     * the right logback setup file.
+     * <p>
+     * To complicate matters further, logback require included files to encapsulate the concrete setup in
+     * {@code <included>} instead of {@code <configuration>} so in order to stay backwards compatible (and forward
+     * compatible as the JNDI-problem is probably solved at some point in the future), a tiny configuration is
+     * created at runtime, including the real configuration.
+     */
+    private void initLogging() {
+        try {
+            if (Resolver.resolveURL("logback-test.xml") != null) {
+                log.info("Logback config 'logback-test.xml' found. Running in test mode");
+                return;
+            }
+
+        } catch (Exception e) {
+            // We might want to skip this logging as it will log to the unconfigured logback at this point
+            log.debug("Logback config 'logback-test.xml' not found. Attempting explicit logback configuration");
+        }
+
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        String logbackFile = null;
+        try {
+            InitialContext ctx = new InitialContext();
+
+            // Resolve the configured setup for logback
+            logbackFile = (String) ctx.lookup(LOGBACK_ENV);
+
+            // Check for logback setup file existence (throws an exception if it fails)
+            Resolver.resolveURL(logbackFile);
+
+            // Create a temporary file that includes the real config file (see JavaDoc for this method for details)
+            File redirect = createRedirect(logbackFile);
+
+            // https://dennis-xlc.gitbooks.io/the-logback-manual/content/en/chapter-3-configuration/configuration-in-logback/invoking-joranconfigurator-directly.html
+            JoranConfigurator configurator = new JoranConfigurator();
+            configurator.setContext(context);
+            context.reset();
+            configurator.doConfigure(redirect);
+
+            log.info("Successfully reconfigured logback with '{}'", logbackFile);
+        } catch (NamingException e) {
+            log.warn("Failed to lookup logback config file from context '{}'. Continuing", LOGBACK_ENV, e);
+        } catch (JoranException e) {
+            StatusPrinter.printInCaseOfErrorsOrWarnings(context);
+            throw new RuntimeException("Failed to configure logger from '" + logbackFile + "'", e);
+        } catch (MalformedURLException | FileNotFoundException e) {
+            log.warn("Resolved '{}' to path '{}', which does not exist. Continuing", LOGBACK_ENV, logbackFile);
+        }
+    }
+
+    /**
+     * Create a logback redirection file that points to the true logback configuration.
+     * See {@link #initLogging()} for details.
+     * @param logbackFile the real configuration for logback as a file on the local filesystem.
+     * @return a logback config that includes {@code logbackFile}.
+     */
+    private static File createRedirect(String logbackFile) {
+        File redirectFile;
+        try {
+            redirectFile = File.createTempFile("logback-loader_", ".xml");
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Unable to create temporary file for logback configuration of '" + logbackFile + "'", e);
+        }
+        redirectFile.deleteOnExit();
+
+        try {
+            String redirectContent =
+                    "<configuration>\n" +
+                            "<include file=\"" + logbackFile + "\"/>\n" +
+                            "</configuration>\n";
+            Files.saveString(redirectContent, redirectFile);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Unable to save redirect logback for '" + logbackFile + "' to temp file '" + redirectFile + "'", e);
+        }
+
+        return redirectFile;
     }
 
 


### PR DESCRIPTION
In previous versions og logback, the config
```xml
<configuration scan="true" scanPeriod="5 minutes">
    <insertFromJNDI env-entry-name="java:comp/env/ds-image-logback-config" as="logbackConfiguration"/>
    <include file="${logbackConfiguration}"/>
</configuration>
```
allowed the service to be initialized by specifying `ds-image-logback-config` in the tomcat context and pointing it to the "real" logback config. Unfortunately this broke after upgrade, apparently due to the `JNDI`-insertion being called _after_ `include file...`!?

This pull request is not as much a fix as it is a hack: It performs the same steps as above, just programmatically in `Application_v1.java`. The original redirecting `logback.xml` is kept in the repo as future versions of logback might make the `JNDI`+`redirect` work again.

If this is acceptable, I suggest moving the workaround code to `kb-util` so that applying the workaround to other projects becomes a simple call to `initLogging("my-project-name")`.