### PR TITLE
Disc 31 accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+-  Accept header transfered to image server request
+
 ### Changed
 
 ## [1.3.0](https://github.com/kb-dk/ds-image/releases/tag/ds-image-1.3.0) - 2024-01-22

--- a/src/main/java/dk/kb/image/IIIFFacade.java
+++ b/src/main/java/dk/kb/image/IIIFFacade.java
@@ -71,6 +71,8 @@ public class IIIFFacade {
      *
      * @param format: The format of the returned image is expressed as a suffix, mirroring common filename extensions.
      *
+     * @param httpHeaders the original httpHeaders from the client. Used to transfer specific header fields to image server request.
+     *
      * @return <ul>
       *   <li>code = 200, message = "Succes!", response = File.class</li>
       *   <li>code = 400, message = "Bad Request. Please check the formating of the parameters: region, size and rotation.  Check if the requested region’s height or width is zero, or if the region is entirely outside the bounds of the reported dimensions  Requests for sizes not prefixed with ^ that result in a scaled region with pixel dimensions greater than the pixel dimensions of the extracted region are errors that should result in a 400 (Bad Request) status code.  Check for syntax errors in size parameter  A rotation value that is out of range or unsupported should result in a 400 (Bad Request) status code."</li>
@@ -108,8 +110,11 @@ public class IIIFFacade {
     /**
      * IIIF Image Information
      *
-     * @param identifier: The identifier of the requested image. This may be an ARK, URN, filename, or other identifier. Special characters must be URI encoded.
-     *
+     * @param requestUri the original request URI from the client. Used only for logging.
+     * @param identifier: The identifier of the requested image. This may be an ARK, URN, filename, or other identifier. Special characters must be URI encoded.    
+     * @param extension Data format. 'json' or 'xml' allowed.
+     * @param httpHeaders the original httpHeaders from the client. Used to transfer specific header fields to image server request.
+     * 
      * @return <ul>
       *   <li>code = 200, message = "Succes!", response = JsonldDto.class</li>
       *   </ul>

--- a/src/main/java/dk/kb/image/IIIFFacade.java
+++ b/src/main/java/dk/kb/image/IIIFFacade.java
@@ -15,12 +15,15 @@
 package dk.kb.image;
 
 import com.damnhandy.uri.template.UriTemplate;
+
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.util.webservice.exception.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
@@ -77,7 +80,7 @@ public class IIIFFacade {
       * @implNote return will always produce a HTTP 200 code. Throw ServiceException if you need to return other codes
      */
     public StreamingOutput getIIIFImage(URI requestURI, String identifier, String region, String size,
-                                        String rotation, String quality, String format) {
+                                        String rotation, String quality, String format, HttpHeaders httpHeaders) {
         validateIIIFImageRequest(requestURI, identifier, region, size, rotation, quality, format);
         if (format == null) {
             format = "jpg";
@@ -98,7 +101,7 @@ public class IIIFFacade {
                 path(path);
 
         final URI uri = builder.build();
-        return ProxyHelper.proxy(identifier, uri, requestURI);
+        return ProxyHelper.proxy(identifier, uri, requestURI,httpHeaders);
     }
 
 
@@ -114,7 +117,7 @@ public class IIIFFacade {
       *
       * @implNote return will always produce a HTTP 200 code. Throw ServiceException if you need to return other codes
      */
-    public StreamingOutput getIIIFInfo(URI requestURI, String identifier, String extension) {
+    public StreamingOutput getIIIFInfo(URI requestURI, String identifier, String extension, HttpHeaders httpHeaders) {
         // TODO: Verify extension
         String path = UriTemplate.fromTemplate(IIIF_INFO3_TEMPLATE)
                 .set("identifier", identifier)
@@ -125,7 +128,7 @@ public class IIIFFacade {
                 path(path);
 
         final URI uri = builder.build();
-        return ProxyHelper.proxy(identifier, uri, requestURI);
+        return ProxyHelper.proxy(identifier, uri, requestURI,httpHeaders);
     }
 
     /**

--- a/src/main/java/dk/kb/image/IIPFacade.java
+++ b/src/main/java/dk/kb/image/IIPFacade.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
@@ -96,7 +97,7 @@ public class IIPFacade {
             URI requestURI,
             String FIF, Long WID, Long HEI, List<Float> RGN, Integer QLT, Float CNT,
             String ROT, Float GAM, String CMP, String PFL, String CTW, Boolean INV, String COL,
-            List<Integer> JTL, List<Integer> PTL, String CVT) throws ServiceException {
+            List<Integer> JTL, List<Integer> PTL, String CVT, HttpHeaders httpHeaders) throws ServiceException {
 
         IIPParamValidation.validateIIPRequest(FIF, WID, HEI, RGN, QLT, CNT, ROT, GAM, CMP, PFL, CTW, INV, COL, JTL, PTL, CVT);
 
@@ -130,12 +131,12 @@ public class IIPFacade {
 
         final URI uri = builder.build();
 
-        return ProxyHelper.proxy(FIF, uri, requestURI);
+        return ProxyHelper.proxy(FIF, uri, requestURI, httpHeaders);
     }
 
     public javax.ws.rs.core.StreamingOutput getDeepzoomDZI(
             URI requestURI, String imageid,
-            HttpServletResponse httpServletResponse) throws ServiceException {
+            HttpServletResponse httpServletResponse,  HttpHeaders httpHeaders) throws ServiceException {
         validateDeepzoomDZIRequest(imageid);
         final String idDZI = imageid + (imageid.endsWith(".dzi") ? "" : ".dzi");
         // Defaults
@@ -159,13 +160,13 @@ public class IIPFacade {
 
         final URI uri = builder.build();
 
-        return ProxyHelper.proxy(imageid, uri, requestURI, httpServletResponse);
+        return ProxyHelper.proxy(imageid, uri, requestURI, httpServletResponse, httpHeaders);
     }
 
     public javax.ws.rs.core.StreamingOutput getDeepzoomTile(
             URI requestURI,
             String imageid, Integer layer, String tiles, String format, Float CNT,
-            Float GAM, String CMP, String CTW, Boolean INV, String COL) throws ServiceException {
+            Float GAM, String CMP, String CTW, Boolean INV, String COL, HttpHeaders httpHeaders) throws ServiceException {
         IIPParamValidation.validateDeepzoomTileRequest(imageid, layer, tiles, format, CNT, GAM, CMP, CTW, INV, COL);
 
         // Defaults
@@ -204,7 +205,7 @@ public class IIPFacade {
 
         final URI uri = builder.build();
 
-        return ProxyHelper.proxy(imageid, uri, requestURI);
+        return ProxyHelper.proxy(imageid, uri, requestURI,httpHeaders);
     }
 
     /**

--- a/src/main/java/dk/kb/image/IIPFacade.java
+++ b/src/main/java/dk/kb/image/IIPFacade.java
@@ -90,6 +90,8 @@ public class IIPFacade {
      *
      * @param CVT: Export the full image or a region in the specified format (JPEG and PNG currently supported)
      *
+     * @param httpHeaders the original httpHeaders from the client. Used to transfer specific header fields to image server request.
+     * 
      * @return a bitmap.
      * @throws ServiceException when other http codes should be returned
      */

--- a/src/main/java/dk/kb/image/ProxyHelper.java
+++ b/src/main/java/dk/kb/image/ProxyHelper.java
@@ -75,7 +75,7 @@ public class ProxyHelper {
             String acceptHeader = (httpHeaders != null)  ? httpHeaders.getHeaderString(HEADER_ACCEPT) : null; 
 
         //If more headerfields besides Accept is transfered to proxy request add them to log.
-    	log.debug("proxy(request='{}', uri='{}', clientRequestURI='{}', httpServletResponse={}, acceptHeader{}) called",
+    	log.debug("proxy(request='{}', uri='{}', clientRequestURI='{}', httpServletResponse={}, acceptHeader={}) called",
                   request, uri, clientRequestURI, httpServletResponse == null ? "not present" : "present", acceptHeader);
         final HttpURLConnection connection = establishConnection(request, uri, clientRequestURI,httpHeaders);
         try {

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -80,7 +80,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             setFilename(new File(imageid).getName() + ".dzi", false, false);
             return IIPFacade.getInstance().getDeepzoomDZI(
                     uriInfo.getRequestUri(), imageid,
-                    httpServletResponse);
+                    httpServletResponse,httpHeaders);
 
         } catch (Exception e){
             throw handleException(e);
@@ -165,7 +165,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
             return IIPFacade.getInstance().getDeepzoomTile(
                     uriInfo.getRequestUri(),
-                    imageid, layer, tiles, format, CNT, GAM, CMP, CTW, INV, COL);
+                    imageid, layer, tiles, format, CNT, GAM, CMP, CTW, INV, COL, httpHeaders);
 
         } catch (Exception e){
             throw handleException(e);
@@ -223,7 +223,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             httpServletResponse.setHeader("Access-Control-Allow-Origin", "*"); // Access controlled by OAuth2
 
             // TODO: Add support for XML when the OpenAPI specification has been corrected
-            return IIIFFacade.getInstance().getIIIFInfo(uriInfo.getRequestUri(), identifier, "json");
+            return IIIFFacade.getInstance().getIIIFInfo(uriInfo.getRequestUri(), identifier, "json",httpHeaders);
         } catch (Exception e) {
             throw handleException(e);
         }
@@ -310,7 +310,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
 
             return IIIFFacade.getInstance().getIIIFImage(
                     uriInfo.getRequestUri(),
-                    identifier, region, size, rotation, quality, format);
+                    identifier, region, size, rotation, quality, format,httpHeaders);
         } catch (Exception e) {
             throw handleException(e);
         }
@@ -391,7 +391,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
 
             return IIPFacade.getInstance().getIIPImage(
                     uriInfo.getRequestUri(),
-                    FIF, WID, HEI, RGN, QLT, CNT, ROT, GAM, CMP, PFL, CTW, INV, COL, JTL, PTL, CVT);
+                    FIF, WID, HEI, RGN, QLT, CNT, ROT, GAM, CMP, PFL, CTW, INV, COL, JTL, PTL, CVT,httpHeaders);
         } catch (Exception e) {
             throw handleException(e);
         }

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -366,9 +366,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
     public StreamingOutput iIPImageRequest(
             String FIF, Long WID, Long HEI, List<Float> RGN, Integer QLT, Float CNT, String ROT, Float GAM, String CMP, String PFL, String CTW, Boolean INV, String COL,
             List<Integer> JTL, List<Integer> PTL, String CVT) throws ServiceException {
-        try {
-     
-            log.info("ACCEPT HEADER:"+httpHeaders.getHeaderString("Accept"));
+        try {     
             log.debug("IIPImageRequest(FIF='{}', WID={}, HEI={}, RGN={}, QLT={}, CNT={}, " +
                       "ROT={}, GAM={}, CMP='{}', PFL='{}', CTW='{}', INV={}, COL='{}', " +
                       "JTL={}, PTL={}, CVT='{}') called with call details: {}",

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -367,6 +367,8 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             String FIF, Long WID, Long HEI, List<Float> RGN, Integer QLT, Float CNT, String ROT, Float GAM, String CMP, String PFL, String CTW, Boolean INV, String COL,
             List<Integer> JTL, List<Integer> PTL, String CVT) throws ServiceException {
         try {
+     
+            log.info("ACCEPT HEADER:"+httpHeaders.getHeaderString("Accept"));
             log.debug("IIPImageRequest(FIF='{}', WID={}, HEI={}, RGN={}, QLT={}, CNT={}, " +
                       "ROT={}, GAM={}, CMP='{}', PFL='{}', CTW='{}', INV={}, COL='{}', " +
                       "JTL={}, PTL={}, CVT='{}') called with call details: {}",

--- a/src/test/java/dk/kb/image/ProxyHelperTest.java
+++ b/src/test/java/dk/kb/image/ProxyHelperTest.java
@@ -35,7 +35,7 @@ class ProxyHelperTest {
     @Test
     void anyBytes() throws IOException, URISyntaxException {
         try (ByteArrayOutputStream content = new ByteArrayOutputStream()) {
-            ProxyHelper.proxy("KB", new URI("https://www.kb.dk/"), new URI("http://example.com/irrelevantfortesting")).write(content);
+            ProxyHelper.proxy("KB", new URI("https://www.kb.dk/"), new URI("http://example.com/irrelevantfortesting"),null).write(content);
             assertTrue(content.size() >= 1, "The resulting content should have at least 1 byte");
         }
     }
@@ -48,7 +48,7 @@ class ProxyHelperTest {
             ProxyHelper.proxy("KB",
                               new URI("https://www.kb.dk/"),
                               new URI("http://example.com/irrelevantfortesting"),
-                              servletResponse).
+                              servletResponse,null).
                     write(content);
             assertTrue(content.size() >= 1, "The resulting content should have at least 1 byte");
         }


### PR DESCRIPTION
Very easy fix.  Take the HttpHeader from the servlet context, and add it to every method in the chain down to the proxy stream construction.
For every image request, the following line will be added to the log:

INFO  dk.kb.image.ProxyHelper - Transfering accept header:text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
