### PR TITLE
Disc 847 thumbnails from kaltura

### DIFF
--- a/conf/ds-image-behaviour.yaml
+++ b/conf/ds-image-behaviour.yaml
@@ -43,5 +43,5 @@ thumbnail:
 kaltura: 
   url:  https://kmc.kaltura.nordu.net
   partnerId:  380
-  userId:  teg@kb.dk
+  userId:  xxx@kb.dk
   adminSecret: very very secret

--- a/conf/ds-image-behaviour.yaml
+++ b/conf/ds-image-behaviour.yaml
@@ -40,3 +40,8 @@ thumbnail:
   max_height: 150
   max_width: 150
   
+kaltura: 
+  url:  https://kmc.kaltura.nordu.net
+  partnerId:  380
+  userId:  teg@kb.dk
+  adminSecret: very very secret

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
 
         
-        <!--For getting tumbnails from Kaltura -->
+        <!--For getting thumbnails from Kaltura -->
         <dependency>
             <groupId>com.kaltura</groupId>
             <artifactId>KalturaClient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
             <version>1.8</version>
         </dependency>
 
+        
+        <!--For getting tumbnails from Kaltura -->
+        <dependency>
+            <groupId>com.kaltura</groupId>
+            <artifactId>KalturaClient</artifactId>
+            <version>3.3.1</version>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -263,7 +270,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -452,6 +452,19 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
         }
     }
 
+    
+    /**
+     * Return is a list of links that will generate thumbnail for the give program.<br>
+     * The first link in the list is the sprite containing all thumbnails.
+     * 
+     * @param fileId The externalId we have for the record. 
+     * @param numberOfSlices Number of thumbnails. They be divided uniform over the video.
+     * @param width Optional width parameter in pixels. Aspect ratio will be kept.
+     * @param height Optional height parameter in pixels. Aspect ratio will be kept. 
+     * 
+     * @return List of links. The first link in the list is the sprite containing all thumbnails.
+     * @throws Exception If the fileId is not found or internal server error with Kaltura
+     */
     @Override
     public List<String> kalturaThumbnails(String fileId,Integer numberOfThumbnails, Integer width, Integer height) throws  ServiceException{
      

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -7,9 +7,11 @@ import dk.kb.image.config.ServiceConfig;
 import dk.kb.image.model.v1.DeepzoomDZIDto;
 import dk.kb.image.model.v1.IIIFInfoDto;
 import dk.kb.image.util.ImageAccessValidation;
+import dk.kb.image.util.KalturaUtil;
 import dk.kb.util.Pair;
 import dk.kb.util.webservice.ImplBase;
 import dk.kb.util.webservice.exception.InternalServiceException;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.util.webservice.exception.ServiceException;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -18,7 +20,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.util.List;
@@ -444,6 +450,23 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
             default:
                 throw new InternalServiceException("Unknown format, unable to determine mime type: '" + format + "'");
         }
+    }
+
+    @Override
+    public List<String> kalturaThumbnails(String fileId,Integer numberOfThumbnails, Integer width, Integer height) throws  ServiceException{
+     
+        if ( fileId == null) {
+            throw new InvalidArgumentServiceException("FileId must not be null");
+        }
+        
+        try {
+            List<String> thumbnails = KalturaUtil.getThumbnails(fileId, numberOfThumbnails, width, height);
+            return thumbnails;
+        }
+        catch(Exception e) {
+            log.error("Error getting thumbnails from Kaltura",e);
+            throw new ServiceException("Error getting thumbnails from Kaltura",Response.Status.INTERNAL_SERVER_ERROR); 
+        }               
     }
 
 }

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -6,6 +6,7 @@ import dk.kb.image.api.v1.AccessApi;
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.image.model.v1.DeepzoomDZIDto;
 import dk.kb.image.model.v1.IIIFInfoDto;
+import dk.kb.image.model.v1.ThumbnailsDto;
 import dk.kb.image.util.ImageAccessValidation;
 import dk.kb.image.util.KalturaUtil;
 import dk.kb.util.Pair;
@@ -462,22 +463,21 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
      * @param width Optional width parameter in pixels. Aspect ratio will be kept.
      * @param height Optional height parameter in pixels. Aspect ratio will be kept. 
      * 
-     * @return List of links. The first link in the list is the sprite containing all thumbnails.
+     * @return ThumbnailsDto. Has a default thumbnail, a sprite and list of time sliced thumbnails.
      * @throws Exception If the fileId is not found or internal server error with Kaltura
      */
     @Override
-    public List<String> kalturaThumbnails(String fileId,Integer numberOfThumbnails, Integer width, Integer height) throws  ServiceException{
+    public ThumbnailsDto kalturaThumbnails(String fileId,Integer numberOfThumbnails, Integer width, Integer height) throws  ServiceException{
      
         if ( fileId == null) {
             throw new InvalidArgumentServiceException("FileId must not be null");
-        }
-        
+        }        
         try {
-            List<String> thumbnails = KalturaUtil.getThumbnails(fileId, numberOfThumbnails, width, height);
+           ThumbnailsDto thumbnails = KalturaUtil.getThumbnails(fileId, numberOfThumbnails, width, height);
             return thumbnails;
         }
         catch(Exception e) {
-            log.error("Error getting thumbnails from Kaltura",e);
+            log.warn("Error getting thumbnails from Kaltura for. Error={},fileId={},numberofThumbnails={},width={},height={}",e.getMessage(),fileId,numberOfThumbnails,width,height);
             throw new ServiceException("Error getting thumbnails from Kaltura",Response.Status.INTERNAL_SERVER_ERROR); 
         }               
     }

--- a/src/main/java/dk/kb/image/kaltura/DsKalturaClient.java
+++ b/src/main/java/dk/kb/image/kaltura/DsKalturaClient.java
@@ -1,0 +1,89 @@
+package dk.kb.image.kaltura;
+
+import java.util.ArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.kaltura.client.KalturaApiException;
+import com.kaltura.client.KalturaClient;
+import com.kaltura.client.KalturaConfiguration;
+import com.kaltura.client.enums.KalturaSessionType;
+import com.kaltura.client.types.KalturaFilterPager;
+import com.kaltura.client.types.KalturaMediaEntry;
+import com.kaltura.client.types.KalturaMediaEntryFilter;
+import com.kaltura.client.types.KalturaMediaListResponse;
+
+/**
+ * Kaltura client that can: 
+ * 1) API lookup and map external ID to internal ID 
+ */
+public class DsKalturaClient {
+
+    private KalturaClient client = null;
+    private static final Logger log = LoggerFactory.getLogger(DsKalturaClient.class);
+
+    /**
+     * Instantiate a session to Kaltura that can be used to upload files. The session can be be reused for multiple uploads etc.
+     * 
+     * @param kalturaUrl The Kaltura API url. Using the baseUrl will automatic append the API service part to the URL. 
+     * @param userId The userId that must be defined in the kaltura, userId is email xxx@kb.dk in our kaltura
+     * @param partnerId The partner id for kaltura. Kind of a collectionId. 
+     * @param adminSecret The admin secret that must not be shared that gives access to API
+     */
+    public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String adminSecret) throws Exception {
+        try {
+            KalturaConfiguration config = new KalturaConfiguration();
+            config.setEndpoint(kalturaUrl);
+            KalturaClient client = new KalturaClient(config);
+            String ks = client.generateSession(adminSecret, userId, KalturaSessionType.ADMIN, partnerId);
+            client.setKs(ks);
+            this.client=client;
+        }
+        catch (Exception e) {
+            log.error("Connecting to Kaltura failed for kaltura url:"+kalturaUrl,e.getMessage());
+            throw new Exception (e);
+        }
+
+    }
+    
+    
+    /**
+     * Search Kaltura for a referenceId. The referenceId was given to Kaltura when uploading the record.<br>
+     * We use filenames (file_id) as refereceIds. Example: b16bc5cb-1ea9-48d4-8e3c-2a94abae501b <br>
+     * <br> 
+     * The Kaltura response contains a lot more information that is required, so it is not a light weight call against Kaltura.
+     *  
+     * @param referenceId External reference ID given when uploading the entry to Kaltura.
+     * @return The Kaltura id (internal id). Return null if the refId is not found.
+     * @throws  Throws KalturaApiException if kaltura called fails, or more than 1 entry was found with the referenceId.
+     */
+    public String getKulturaInternalId(String referenceId) throws   KalturaApiException{
+
+        KalturaFilterPager pager = new KalturaFilterPager();
+        pager.pageSize = 10;
+                
+        KalturaMediaEntryFilter filter = new KalturaMediaEntryFilter();                
+        //filter.searchTextMatchAnd="\""+referenceId+"\""; // Can also find with freetext search (quotes), but this can give false matches.
+        filter.referenceIdEqual=referenceId;
+        KalturaMediaListResponse list = client.getMediaService().list(filter,pager);               
+
+        if (list.totalCount == 0) {
+            log.warn("No entry found at Kaltura for referenceId:"+referenceId);// warn since method it should happen if given a referenceId
+            return null;
+        }
+        if (list.totalCount >1) { //Sanity, has not happened yet.
+            log.error("More that one entry was found at Kaltura for referenceId:"+referenceId);
+            throw new KalturaApiException("More than 1 entry found at Kaltura for referenceId:"+referenceId);
+        }
+        
+        ArrayList<KalturaMediaEntry> objects = list.objects;
+        KalturaMediaEntry entry = objects.get(0); //There is all meta information here if needed.
+        return entry.id;        
+    }
+    
+}
+
+
+
+

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -77,7 +77,7 @@ public class KalturaUtil {
     }
 
     
-    public static DsKalturaClient getClientInstance() throws IOException{
+    public synchronized DsKalturaClient getClientInstance() throws IOException{
         if (System.currentTimeMillis()-lastSessionStart >= reloadIntervalInMillis) {            
             //Create the client
             String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -8,24 +8,28 @@ import dk.kb.image.kaltura.DsKalturaClient;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 public class KalturaUtil {
-    
-    public static void main(String[] args) throws Exception {
-       String fileId="09139243-9a7a-422f-b597-7aa59b06ab7d";
-     List<String> links=   getThumbnails(fileId, 10,200, null);
-     System.out.println(links);
-    }
-   
-    
-    /*
+          
+    /**
      * 
-     * Example url: //https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/
+     * Example url to the sprite with all thumbnails:
+     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/
      * 
+     * Example url to slice #5 out of 10
+     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/vid_slice/5
+     * 
+     * @param fileId The externalId we have for the record. 
+     * @param numberOfSlices Number of thumbnails. They be divided uniform over the video.
+     * @param width Optional width parameter in pixels. Aspect ratio will be kept.
+     * @param height Optiomal height parameter in pixels. Aspect ratio will be kept. 
+     * 
+     * @return List of links. The first link in the list is the sprite containing all thumbnails.
+     * @throws Exception If the fileId is not found or internal server error with Kaltura
      */
     public static List<String> getThumbnails(String fileId,Integer numberOfSlices, Integer width, Integer height) throws Exception{        
         List<String> imageLinks= new ArrayList<String>();
         //Create the client
         String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
-        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); 
+        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed.
         Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
         String userId = ServiceConfig.getConfig().getString("kaltura.userId");
         DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);
@@ -34,8 +38,7 @@ public class KalturaUtil {
         if (kalturaId == null) {
             throw new InvalidArgumentServiceException("FileId not found at Kaltura:"+fileId);
         }
-        
-        
+                
         String baseUrl=kalturaUrl+"/p/"+partnerId+"/thumbnail/entry_id/"+kalturaId;
         //String baseUrl="https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/"+kalturaId;
         if (width != null && width.intValue() > 0) {

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -77,17 +77,17 @@ public class KalturaUtil {
     }
 
     
-    public synchronized DsKalturaClient getClientInstance() throws IOException{
+    public  synchronized static DsKalturaClient getClientInstance() throws IOException{
         if (System.currentTimeMillis()-lastSessionStart >= reloadIntervalInMillis) {            
             //Create the client
             String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
             String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed.
             Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
             String userId = ServiceConfig.getConfig().getString("kaltura.userId");
-            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);  
+            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);             
             clientInstance=client;
             log.info("Started a new Kaltura session");
-            lastSessionStart=System.currentTimeMillis(); //Reset timer
+            lastSessionStart=System.currentTimeMillis(); //Reset timer           
             return clientInstance;
         }
         return clientInstance; //Reuse existing connection.

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -1,61 +1,97 @@
 package dk.kb.image.util;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.image.kaltura.DsKalturaClient;
+import dk.kb.image.model.v1.ThumbnailsDto;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 
 public class KalturaUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(KalturaUtil.class);
+    private static DsKalturaClient clientInstance = null;
+    private static long lastSessionStart=0;
+    private static long reloadIntervalInMillis=1L*24*60*60*1000; // 1 day
           
     /**
      * 
-     * Example url to the sprite with all thumbnails:
-     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/
+     * Example url to the sprite with all thumbnails:<br>
+     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/<br>
+     * <br>
+     * Example url to slice #5 out of 10<br>
+     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/vid_slice/5<br>
      * 
-     * Example url to slice #5 out of 10
-     * https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/vid_slice/5
+     * See <a href="https://developer.kaltura.com/api-docs/Engage_and_Publish/kaltura-thumbnail-api.html">Kaltura Thumbnail API</a> 
+     * 
      * 
      * @param fileId The externalId we have for the record. 
      * @param numberOfSlices Number of thumbnails. They be divided uniform over the video.
      * @param width Optional width parameter in pixels. Aspect ratio will be kept.
      * @param height Optiomal height parameter in pixels. Aspect ratio will be kept. 
      * 
-     * @return List of links. The first link in the list is the sprite containing all thumbnails.
-     * @throws Exception If the fileId is not found or internal server error with Kaltura
+     * @return ThumbnailsDto. Has a default thumbnail, a sprite and list of time sliced thumbnails.
+     * @throws IOException If the fileId is not found or internal server error with Kaltura.
      */
-    public static List<String> getThumbnails(String fileId,Integer numberOfSlices, Integer width, Integer height) throws Exception{        
-        List<String> imageLinks= new ArrayList<String>();
-        //Create the client
+    public static ThumbnailsDto getThumbnails(String fileId,Integer numberOfSlices, Integer width, Integer height) throws IOException{        
+        ThumbnailsDto thumbnails = new ThumbnailsDto();
         String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
-        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed.
         Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
-        String userId = ServiceConfig.getConfig().getString("kaltura.userId");
-        DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);
+        
+        DsKalturaClient client = getClientInstance();
         String kalturaId = client.getKulturaInternalId(fileId);                     
         
         if (kalturaId == null) {
             throw new InvalidArgumentServiceException("FileId not found at Kaltura:"+fileId);
-        }
-                
+        }                
         String baseUrl=kalturaUrl+"/p/"+partnerId+"/thumbnail/entry_id/"+kalturaId;
-        //String baseUrl="https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/"+kalturaId;
+      
         if (width != null && width.intValue() > 0) {
             baseUrl=baseUrl+"/width/"+width;
         }
         if (height != null && height.intValue() > 0) {
             baseUrl=baseUrl+"/height/"+height;
         }
-        baseUrl=baseUrl+"/vid_slices/"+numberOfSlices; //This is the sprite version will all thumbnails
 
-        imageLinks.add(baseUrl); 
+        thumbnails.setDefault(baseUrl); // Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/
+
+        //This is the sprite version will all thumbnails.
+        //Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10
+        baseUrl=baseUrl+"/vid_slices/"+numberOfSlices; 
+
+        List<String> timeSliceThumbnails= new ArrayList<String>();
+        thumbnails.setSprite(baseUrl); 
         //Add the images slices 
         for (int i=0;i<numberOfSlices;i++ ) {
-           imageLinks.add(baseUrl +"/vid_slice/"+i);  //Yes, slices start with value=0
+            //example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10/vid_slice/5
+            timeSliceThumbnails.add(baseUrl +"/vid_slice/"+i);  //Yes, slices start with value=0.           
         }
-        
-        return imageLinks;                        
+        thumbnails.setThumbnails(timeSliceThumbnails);
+
+        return thumbnails;          
     }
 
+    
+    public static DsKalturaClient getClientInstance() throws IOException{
+        if (System.currentTimeMillis()-lastSessionStart >= reloadIntervalInMillis) {            
+            //Create the client
+            String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
+            String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed.
+            Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
+            String userId = ServiceConfig.getConfig().getString("kaltura.userId");
+            DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);  
+            clientInstance=client;
+            log.info("Started a new Kaltura session");
+            lastSessionStart=System.currentTimeMillis(); //Reset timer
+            return clientInstance;
+        }
+        return clientInstance; //Reuse existing connection.
+        
+    }
+    
 }

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -1,0 +1,58 @@
+package dk.kb.image.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dk.kb.image.config.ServiceConfig;
+import dk.kb.image.kaltura.DsKalturaClient;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
+
+public class KalturaUtil {
+    
+    public static void main(String[] args) throws Exception {
+       String fileId="09139243-9a7a-422f-b597-7aa59b06ab7d";
+     List<String> links=   getThumbnails(fileId, 10,200, null);
+     System.out.println(links);
+    }
+   
+    
+    /*
+     * 
+     * Example url: //https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_jym3ia3g/width/200/vid_slices/10/
+     * 
+     */
+    public static List<String> getThumbnails(String fileId,Integer numberOfSlices, Integer width, Integer height) throws Exception{        
+        List<String> imageLinks= new ArrayList<String>();
+        //Create the client
+        String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
+        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); 
+        Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
+        String userId = ServiceConfig.getConfig().getString("kaltura.userId");
+        DsKalturaClient client = new DsKalturaClient(kalturaUrl,userId,partnerId,adminSecret);
+        String kalturaId = client.getKulturaInternalId(fileId);                     
+        
+        if (kalturaId == null) {
+            throw new InvalidArgumentServiceException("FileId not found at Kaltura:"+fileId);
+        }
+        
+        
+        String baseUrl=kalturaUrl+"/p/"+partnerId+"/thumbnail/entry_id/"+kalturaId;
+        //String baseUrl="https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/"+kalturaId;
+        if (width != null && width.intValue() > 0) {
+            baseUrl=baseUrl+"/width/"+width;
+        }
+        if (height != null && height.intValue() > 0) {
+            baseUrl=baseUrl+"/height/"+height;
+        }
+        baseUrl=baseUrl+"/vid_slices/"+numberOfSlices; //This is the sprite version will all thumbnails
+
+        imageLinks.add(baseUrl); 
+        //Add the images slices 
+        for (int i=0;i<numberOfSlices;i++ ) {
+           imageLinks.add(baseUrl +"/vid_slice/"+i);  //Yes, slices start with value=0
+        }
+        
+        return imageLinks;                        
+    }
+
+}

--- a/src/main/openapi/ds-image-openapi_v1.yaml
+++ b/src/main/openapi/ds-image-openapi_v1.yaml
@@ -507,17 +507,15 @@ paths:
                 type: string
                 format: binary
 
-  /kaltura/tumbnails/:
+  /kaltura/thumbnails/:
     get:
       tags:
         - 'Access'
-      summary: 'Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.'
+      summary: ' Get urls to thumbnail video images at Kaltura for a record identified by file_id field in Solr.'
       description: |-       
-       Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.
-          
-       The list will contain links to thumbnails. The first link will be a sprite of all images.
-          
-       The other entries will be links to that slice number of the video.
+        Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.          
+        Will contain a default thumbnail, a sprite and list of time sliced thumbnails.     
+        [Kaltura Thumbnail API](https://developer.kaltura.com/api-docs/Engage_and_Publish/kaltura-thumbnail-api.html)                     
       operationId: kalturaThumbnails
       parameters:
         - name: fileId
@@ -558,12 +556,7 @@ paths:
           content:
             application/json:
              schema:
-              type: array
-              items: 
-                type: string
-                
-                 
-                  
+                $ref: '#/components/schemas/Thumbnails'                    
               
   # The ping service should be in all projects, should not do any advanced processing
   # and should respond quickly with a simple message, e.g. "pong".
@@ -893,6 +886,24 @@ components:
               xml:
                 attribute: true
               example: 4752
+
+ # Thumbnails to Kaltura
+    Thumbnails:
+      type: object
+      properties:
+        default:
+          type: string
+          description: 'Default thumbnail defined for the video. This is a thumbnail that can be changed by Kaltura administrators'      
+        sprite:
+          type: string
+          description: 'Link to image with all thumbnails.'            
+        thumbnails:        
+          type: array
+          description: 'List to the time slice thumbnails in chronological order ' 
+          items: 
+            type: string
+
+ 
     # Basic status response component.
     Status:
       type: object

--- a/src/main/openapi/ds-image-openapi_v1.yaml
+++ b/src/main/openapi/ds-image-openapi_v1.yaml
@@ -506,7 +506,63 @@ paths:
               schema:
                 type: string
                 format: binary
+
+  /kaltura/tumbnails/:
+    get:
+      tags:
+        - 'Access'
+      summary: 'Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.'
+      description: |-       
+       Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.
           
+       The list will contain links to thumbnails. The first link will be a sprite of all images.
+          
+       The other entries will be links to that slice number of the video.
+      operationId: kalturaThumbnails
+      parameters:
+        - name: fileId
+          in: query
+          description: 'The external file reference to the kaltura'           
+          required: true
+          schema:            
+            type: string
+        - name: numberOfThumbnails
+          in: query
+          description: 'The number of thumbnails. The thumbnails will be spread evenly over the duration of the video. Maximum of 100 is allowed.'
+          required: true
+          schema:            
+            type: integer
+            minimum: 1
+            maximum: 100            
+            default: 10
+        - name: width
+          in: query
+          description: 'Width of the thumbnails'
+          required: false
+          schema:            
+            type: integer
+            minimum: 1
+            maximum: 10000
+        - name: height
+          in: query
+          description: 'Heigth of the thumbnails'
+          required: false
+          schema:            
+            type: integer
+            minimum: 1
+            maximum: 10000            
+                       
+      responses:
+        '200':
+          description: OK. List of links to thumbnail images. First link is a sprite containing all images
+          content:
+            application/json:
+             schema:
+              type: array
+              items: 
+                type: string
+                
+                 
                   
               
   # The ping service should be in all projects, should not do any advanced processing
@@ -545,6 +601,7 @@ paths:
               schema:
                 type: string
 
+  
   # The status service should be in all projects and should provide a list of running jobs,
   # the overall health of the service and similar. While the endpoint should be kept at
   # /monitor/status, the response should be adjusted to fit the application.
@@ -979,8 +1036,6 @@ components:
           type: string
           enum: ["gray", "grey", "binary"]
     
-  
-  
   
   
   


### PR DESCRIPTION
Kaltura integration so frontend can get thumbnail links to videos.
The Kaltura thumbnail API does not accept "referenceId" which is our external reference. So the mapping is required
to find the internal ID what must be used for the thumbnail.

Generate thumbnail service. 
Can test from openAPI: http://devel11:10001/ds-image/api/#/Access/kalturaThumbnails
A valid fileId: 67624fe7-b1d9-4225-8afb-e41d8a1190ac
Which has internal kaltura id: 0_n5o4d0ao