### PR TITLE
Dra 1351 kaltura app token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Using ds-kaltura client v.1.2.5
+- Upgraded ds-kaltura to v.1.2.5
+- Kaltura client uses kaltura app-tokens instead of mastersecret. Two new properties added: kaltura.token and katura.tokenId. Mastersecret can be set to null in property
+
 
 ## [1.6.0](https://github.com/kb-dk/ds-image/releases/tag/ds-image-1.6.0) - 2024-09-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Using ds-kaltura client v.1.2.5
+
 ## [1.6.0](https://github.com/kb-dk/ds-image/releases/tag/ds-image-1.6.0) - 2024-09-10
 ### Changed
 -  Upgrade to latest Oauth2 classes

--- a/conf/ds-image-behaviour.yaml
+++ b/conf/ds-image-behaviour.yaml
@@ -36,10 +36,13 @@ thumbnail:
   width:
     max: 150
   
+ #Use token and tokenId  instead of admin secret
 kaltura: 
   url:  https://kmc.kaltura.nordu.net
-  partnerId:  380
+  partnerId:  398
   userId:  xxx@kb.dk
+  token: 'yyyyy'
+  tokenId: 'yyyyy'
   adminSecret: very very secret
 
 security:

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
           <groupId>dk.kb.kaltura</groupId>
           <artifactId>ds-kaltura</artifactId>
-          <version>1.2.3</version>
+          <version>1.2.5</version>
           <type>jar</type>
       </dependency>
 


### PR DESCRIPTION
Upgraded ds-kaltura to v.1.2.5
Kaltura client uses kaltura app-tokens instead of mastersecret. Two new properties added: kaltura.token and katura.tokenId. Mastersecret can be set to null in property.
Using kalturaclient as singleton.