### PR TITLE
DRA-2358-remove-kaltura-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ds-image will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### Changed
+
+- Removed kaltura dependency. 
+- Removed most kaltura properties from yaml config. Only ones needed are:  url and partnerId.
+- Service method to generate link to thumbnails now takes kalturaId parameter instead of fileId. This is breaking for frontend.
+
 ## [4.0.0](https://github.com/kb-dk/ds-image/releases/tag/ds-image-4.0.0) - 2026-01-29
 
 ### Fixed

--- a/conf/ds-image-behaviour.yaml
+++ b/conf/ds-image-behaviour.yaml
@@ -40,12 +40,6 @@ thumbnail:
 kaltura: 
   url:  https://kmc.kaltura.nordu.net
   partnerId:  398
-  userId:  xxx@kb.dk
-  token: 'yyyyy'
-  tokenId: 'yyyyy'
-  adminSecret: ''
-  sessionDurationSeconds: 86400
-  sessionRefreshThreshold: 3600
 
 security:
   # The security mode. Valid values are

--- a/pom.xml
+++ b/pom.xml
@@ -71,16 +71,6 @@
         </exclusions>
       </dependency>
 
-        <!--For getting thumbnails from Kaltura -->
-        <dependency>
-            <groupId>dk.kb.kaltura</groupId>
-            <artifactId>ds-kaltura</artifactId>
-            <version>100.0.0-SNAPSHOT</version>
-            <type>jar</type>
-        </dependency>
-
-
-
         <!-- Apache CXF and servlet stuff -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/AccessApiServiceImpl.java
@@ -454,7 +454,7 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
      * Return is a list of links that will generate thumbnail for the give program.<br>
      * The first link in the list is the sprite containing all thumbnails.
      * 
-     * @param fileId The externalId we have for the record. 
+     * @param kalturaId The internal Kltura id given by Kaltura on creation, 
      * @param numberOfThumbnails Number of thumbnails. They be divided uniform over the video.
      * @param width Optional width parameter in pixels. Aspect ratio will be kept.
      * @param height Optional height parameter in pixels. Aspect ratio will be kept. 
@@ -462,13 +462,13 @@ public class AccessApiServiceImpl extends ImplBase implements AccessApi {
      * @return ThumbnailsDto. Has a default thumbnail, a sprite and list of time sliced thumbnails.
      */
     @Override
-    public ThumbnailsDto kalturaThumbnails(String fileId, Integer numberOfThumbnails, Integer secondStartSeek, Integer secondEndSeek, Integer width, Integer height) throws  ServiceException {
+    public ThumbnailsDto kalturaThumbnails(String kalturaId, Integer numberOfThumbnails, Integer secondStartSeek, Integer secondEndSeek, Integer width, Integer height) throws  ServiceException {
      
-        if (fileId == null) {
-            throw new InvalidArgumentServiceException("FileId must not be null");
+        if (kalturaId == null) {
+            throw new InvalidArgumentServiceException("kalturaId must not be null");
         }        
         try {
-           ThumbnailsDto thumbnails = KalturaUtil.getThumbnails(fileId, numberOfThumbnails, secondStartSeek, secondEndSeek,width, height);
+           ThumbnailsDto thumbnails = KalturaUtil.generateThumbnails( kalturaId, numberOfThumbnails, secondStartSeek, secondEndSeek,width, height);
             return thumbnails;
         }
         catch(Exception e) {

--- a/src/main/java/dk/kb/image/util/ImageAccessValidation.java
+++ b/src/main/java/dk/kb/image/util/ImageAccessValidation.java
@@ -19,8 +19,6 @@ import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.StreamingOutput;
 
-import org.apache.commons.io.IOUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -253,7 +251,6 @@ public class ImageAccessValidation {
         return writeImgToStreamingOutput(nonExistingImageName);
     }
 
-    @NotNull
     private static StreamingOutput writeImgToStreamingOutput(String imgName) throws IOException {
         String imgPath = Resolver.getPathFromClasspath(imgName).toString();
         BufferedImage image = ImageIO.read(new File(imgPath));

--- a/src/main/java/dk/kb/image/util/KalturaUtil.java
+++ b/src/main/java/dk/kb/image/util/KalturaUtil.java
@@ -4,22 +4,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.kaltura.client.types.APIException;
-import dk.kb.util.webservice.exception.NotFoundServiceException;
-import dk.kb.util.webservice.exception.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.image.model.v1.ThumbnailsDto;
-import dk.kb.kaltura.client.DsKalturaClient;
-
-import javax.ws.rs.core.Response;
 
 public class KalturaUtil {
 
     private static final Logger log = LoggerFactory.getLogger(KalturaUtil.class);
-    private static DsKalturaClient kalturaClientInstance;
+
     /**
      *
      * Example url to the sprite with all thumbnails:<br>
@@ -31,7 +25,7 @@ public class KalturaUtil {
      * See <a href="https://developer.kaltura.com/api-docs/Engage_and_Publish/kaltura-thumbnail-api.html">Kaltura Thumbnail API</a> 
      *
      *
-     * @param fileId The externalId we have for the record. 
+     * @param kalturaId The internal Kaltura id given by Kaltura on creation 
      * @param numberOfSlices Number of thumbnails. They be divided uniform over the video.
      * @param secondsStartSeek Generated thumbnails in stream from between secondsStartSeek and secondsEndSeek
      * @param secondsEndSeek Generated thumbnails in stream from between secondsStartSeek and secondsEndSeek. secondsEndSeek must be set for seeking to be active. 
@@ -39,77 +33,42 @@ public class KalturaUtil {
      * @param height Optiomal height parameter in pixels. Aspect ratio will be kept. 
      *
      * @return ThumbnailsDto. Has a default thumbnail, a sprite and list of time sliced thumbnails.
-     * @throws IOException If the fileId is not found or internal server error with Kaltura.
      */
-    public static ThumbnailsDto getThumbnails(String fileId,Integer numberOfSlices, Integer secondsStartSeek, Integer secondsEndSeek, Integer width, Integer height) throws ServiceException {
+    public static ThumbnailsDto generateThumbnails(String  kalturaId,Integer numberOfSlices, Integer secondsStartSeek, Integer secondsEndSeek, Integer width, Integer height) {
         ThumbnailsDto thumbnails = new ThumbnailsDto();
         String kalturaUrl= ServiceConfig.getConfig().getString("kaltura.url");
         Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
 
-        try {
-            DsKalturaClient client = getKalturaClient();
-            String kalturaId = client.getKalturaInternalId(fileId);
-
-            if (kalturaId == null) {
-                throw new NotFoundServiceException("FileId not found at Kaltura: '" + fileId + "'.");
-            }
-            log.debug("ReferenceId lookup at kaltura resolved to internalId {} -> {}",fileId,kalturaId);
-            String baseUrl=kalturaUrl+"/p/"+partnerId+"/thumbnail/entry_id/"+kalturaId;
-            if (width != null && width > 0) {
-                baseUrl=baseUrl+"/width/"+width;
-            }
-            if (height != null && height > 0) {
-                baseUrl=baseUrl+"/height/"+height;
-            }
-
-            String seek=""; //if seek not defined, this empty string will just be added
-            if ((secondsEndSeek != null && secondsEndSeek>=0)  || (secondsStartSeek != null && secondsStartSeek>=0)) {
-                seek="?start_sec="+secondsStartSeek+"&end_sec="+secondsEndSeek; 
-            }
-            
-            thumbnails.setDefault(baseUrl); // Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/
-
-            //This is the sprite version will all thumbnails.
-            //Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10
-            baseUrl=baseUrl+"/vid_slices/"+numberOfSlices;
-
-            List<String> timeSliceThumbnails= new ArrayList<>();
-            thumbnails.setSprite(baseUrl);
-            //Add the images slices
-            for (int i=0;i<numberOfSlices;i++ ) {
-                //example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10/vid_slice/5
-                timeSliceThumbnails.add(baseUrl +"/vid_slice/"+i+seek);  //Yes, slices start with value=0.
-            }
-            thumbnails.setThumbnails(timeSliceThumbnails);
-
-            return thumbnails;
-        } catch (IOException | APIException e) {
-            throw new NotFoundServiceException(e);
+        String baseUrl=kalturaUrl+"/p/"+partnerId+"/thumbnail/entry_id/"+kalturaId;
+        if (width != null && width > 0) {
+            baseUrl=baseUrl+"/width/"+width;
         }
-    }
-
-    private static synchronized DsKalturaClient getKalturaClient() throws IOException, APIException {
-
-        if (kalturaClientInstance != null) {
-            return kalturaClientInstance;
+        if (height != null && height > 0) {
+            baseUrl=baseUrl+"/height/"+height;
         }
 
-        String kalturaUrl = ServiceConfig.getConfig().getString("kaltura.url");
-        String adminSecret = ServiceConfig.getConfig().getString("kaltura.adminSecret"); //Must not be shared or exposed. Use token,tokenId.
-        Integer partnerId = ServiceConfig.getConfig().getInteger("kaltura.partnerId");  
-        String userId = ServiceConfig.getConfig().getString("kaltura.userId");                               
-        String token = ServiceConfig.getConfig().getString("kaltura.token");
-        String tokenId = ServiceConfig.getConfig().getString("kaltura.tokenId");
-        int sessionDurationSeconds = ServiceConfig.getConfig().getInteger("kaltura.sessionDurationSeconds");
-        int sessionRefreshThreshold = ServiceConfig.getConfig().getInteger("kaltura.sessionRefreshThreshold");
-        int conversionQueueThreshold = 0;
-        int conversionQueueRetryDelaySeconds = 0;
+        String seek=""; //if seek not defined, this empty string will just be added
+        if ((secondsEndSeek != null && secondsEndSeek>=0)  || (secondsStartSeek != null && secondsStartSeek>=0)) {
+            seek="?start_sec="+secondsStartSeek+"&end_sec="+secondsEndSeek; 
+        }
 
-        log.info("Creating kaltura client for partnerID: '{}'.", partnerId);
-        DsKalturaClient kalturaClient = new DsKalturaClient(kalturaUrl, userId, partnerId, token, tokenId,
-                adminSecret, sessionDurationSeconds, sessionRefreshThreshold, conversionQueueThreshold, conversionQueueRetryDelaySeconds );
-        kalturaClientInstance=kalturaClient;
-        return kalturaClient;    
+        thumbnails.setDefault(baseUrl); // Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/
+
+        //This is the sprite version will all thumbnails.
+        //Example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10
+        baseUrl=baseUrl+"/vid_slices/"+numberOfSlices;
+
+        List<String> timeSliceThumbnails= new ArrayList<>();
+        thumbnails.setSprite(baseUrl);
+        //Add the images slices
+        for (int i=0;i<numberOfSlices;i++ ) {
+            //example: https://api.kaltura.nordu.net/p/380/thumbnail/entry_id/0_dtvciomh/width/200/vid_slices/10/vid_slice/5
+            timeSliceThumbnails.add(baseUrl +"/vid_slice/"+i+seek);  //Yes, slices start with value=0.
+        }
+        thumbnails.setThumbnails(timeSliceThumbnails);
+
+        return thumbnails;
+
     }
 
 }

--- a/src/main/openapi/ds-image-openapi_v1.yaml
+++ b/src/main/openapi/ds-image-openapi_v1.yaml
@@ -527,20 +527,20 @@ paths:
     get:
       tags:
         - 'Access'
-      summary: ' Get urls to thumbnail video images at Kaltura for a record identified by file_id field in Solr.'
+      summary: ' Get urls to thumbnail video images at Kaltura for a record identified by kaltura_id field in Solr.'
       security:
         - KBOAuth:
           - any
       description: |-       
-        Get a list of url to thumbnail vidoe images at Kaltura for a record identified by file_id field in Solr.          
+        Get a list of url to thumbnail vidoe images at Kaltura for a record identified by kaltura_id field in Solr.          
         Will contain a default thumbnail, a sprite and list of time sliced thumbnails.     
         [Kaltura Thumbnail API](https://developer.kaltura.com/api-docs/Engage_and_Publish/kaltura-thumbnail-api.html)                     
       operationId: kalturaThumbnails
    
       parameters:
-        - name: fileId
+        - name: kalturaId
           in: query
-          description: 'The external file reference to the kaltura'           
+          description: 'The internal kaltura entry id given by Kaltura on creation.'           
           required: true
           schema:            
             type: string

--- a/src/test/java/dk/kb/image/ImageAccessValidationTest.java
+++ b/src/test/java/dk/kb/image/ImageAccessValidationTest.java
@@ -11,7 +11,6 @@ import dk.kb.image.config.ConfigAdjuster;
 import dk.kb.image.config.ServiceConfig;
 import dk.kb.util.Resolver;
 import dk.kb.util.webservice.exception.InternalServiceException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Removed kaltura dependency.
- Removed most kaltura properties from yaml config. Only ones needed are:  url and partnerId.
- Service method to generate link to thumbnails now takes kalturaId parameter instead of fileId. This is breaking for frontend.