### PR TITLE
DRA-2708-minimum-client-jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed kaltura dependency. 
 - Removed most kaltura properties from yaml config. Only ones needed are:  url and partnerId.
 - Service method to generate link to thumbnails now takes kalturaId parameter instead of fileId. This is breaking for frontend.
+- Create minimum client jar. Cross module dependencies uses this new jar instead of the full classes jar.
 
 ## [4.0.0](https://github.com/kb-dk/ds-image/releases/tag/ds-image-4.0.0) - 2026-01-29
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,19 @@
         </dependency>
 
         <!-- Client for ds-license. This will also require the org.openapitools dependency-->
-      <dependency>
-        <groupId>dk.kb.license</groupId>
-        <artifactId>ds-license</artifactId>
-          <version>100.0.0-SNAPSHOT</version>
-          <type>jar</type>
-          <classifier>classes</classifier>
-          <exclusions>
-            <exclusion>
-              <groupId>*</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-        </exclusions>
-      </dependency>
+       <dependency>
+            <groupId>dk.kb.license</groupId>
+            <artifactId>ds-license</artifactId>
+            <version>100.0.0-SNAPSHOT</version>
+            <type>jar</type>
+            <classifier>api</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Apache CXF and servlet stuff -->
         <dependency>
@@ -380,8 +380,9 @@
                         </manifest>
                     </archive>
 
-                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
-                    <attachClasses>true</attachClasses>
+                   <!-- Generation of API jar is done seperate plugin and only contains DTOs and client class -->                    
+                   <!-- <attachClasses>true</attachClasses> --> 
+
 
                     <!--Enable maven filtering for the web.xml-->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -405,6 +406,28 @@
                     </webResources>
                 </configuration>
             </plugin>
+
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>            
+               <executions>
+                   <execution>
+                   <id>build-specific-jar</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>jar</goal>
+                   </goals>
+                  <configuration>                
+                      <classifier>api</classifier>
+                      <includes>                       
+                          <include>dk/kb/image/model/**</include>
+                          <include>dk/kb/image/util/DsImageClient*</include>                                            
+                      </includes>
+                 </configuration>
+                 </execution>
+              </executions>
+            </plugin>
+
 
 
             <!-- Used only for mvn jetty:run jetty:run-war -->


### PR DESCRIPTION
Build new minimum client-jar with DTO's and client class only. Use maven jar plugin. New classifier is 'api'.
Remove building old jar for all classes. Cross module dependencies use the new minimum api jar.